### PR TITLE
feat: add route-level go back functionality

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/002-group-join-redirect"
-}
+{"feature_directory":"specs/003-route-back-nav"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,5 +112,6 @@ All tables have RLS enabled.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+[specs/003-route-back-nav/plan.md](specs/003-route-back-nav/plan.md)
 <!-- SPECKIT END -->

--- a/specs/003-route-back-nav/checklists/requirements.md
+++ b/specs/003-route-back-nav/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Route-level Go Back Functionality
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- All 13 checklist items pass on first pass; no [NEEDS CLARIFICATION] markers introduced.

--- a/specs/003-route-back-nav/data-model.md
+++ b/specs/003-route-back-nav/data-model.md
@@ -1,0 +1,5 @@
+# Data Model — Route-level Go Back Functionality
+
+**N/A** — UI-only feature.
+
+No new entities, no schema changes, no new server actions. The only "data" is a static route → parent map (`src/lib/parent-routes.ts`); see `research.md` §R2.

--- a/specs/003-route-back-nav/plan.md
+++ b/specs/003-route-back-nav/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Route-level Go Back Functionality
+
+**Branch**: `003-route-back-nav` | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-route-back-nav/spec.md`
+
+## Summary
+
+Add a single, predictable back affordance to every non–top-level authenticated route so users can return to a logical parent without relying on browser chrome. UI-only feature: shared `BackButton` component plugs into existing breadcrumb/header areas, prefers `router.back()` when in-app history exists, and falls back to a static parent-route map when entering via deep link. Modal routes close instead of going one step further back.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 (strict), React 19, Next.js 16.1.7 (App Router, Turbopack)
+**Primary Dependencies**: `next/navigation`, shadcn/ui (`@ui/button`, icons via `lucide-react`), Tailwind CSS v4
+**Storage**: N/A (no persistence; UI affordance only)
+**Testing**: Existing project conventions — component tests colocated `*.test.tsx`; manual UX verification per Constitution §II
+**Target Platform**: Web (mobile-first, responsive); same browser support as rest of app
+**Project Type**: Single Next.js web app (App Router, route groups `(public)` and `(protected)`)
+**Performance Goals**: Zero added LCP cost — back control is part of existing header SSR. Interaction latency well below 200 ms INP target (`router.back()` is local).
+**Constraints**: Server Component default; new client boundary only inside the `BackButton` itself for `useRouter`/`window.history` access. Bundle delta target < 2 KB gzip.
+**Scale/Scope**: ~5 affected route segments (`/groups/[id]`, `/groups/[id]/expenses/[expenseId]`, `/groups/[id]/expenses`, `/groups/[id]/create`, intercepted modals under `@modal`). Top-level routes (`/groups`, `/auth/*`) excluded.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Code Quality** | PASS | TS strict; `import type` used; alphabetic imports; path aliases (`@ui/`, `@/components/...`); no money types touched; new component lives under `src/components/common/` (shared primitive). No backwards-compat shims. |
+| **II. Testing Standards** | PASS | Component-level unit test for fallback logic (history empty → static parent); UI test for keyboard activation + screen-reader label; modal back-closes-modal test. No DB tests required (no data path). |
+| **III. UX Consistency** | PASS | Built from shadcn/ui `Button` + `lucide-react` icon; Tailwind via Prettier plugin (no manual class ordering). Toast subsystem untouched. Hidden on top-level routes (FR-003). Dark/light mode covered by inheriting `Button` variants. No destructive action — confirmation rule N/A. |
+| **IV. Performance** | PASS | Server Components remain default; only the `BackButton` itself is `"use client"` (justified: requires `useRouter` + `window.history.length`). No new server fetches, no Redux state, no images. Bundle delta < 2 KB gzip. |
+
+**Outcome**: All gates pass; no Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-route-back-nav/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (N/A — UI only)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A — no external interfaces)
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── (protected)/
+│   │   └── groups/
+│   │       ├── [id]/
+│   │       │   ├── page.tsx              # Host BackButton in header
+│   │       │   ├── create/page.tsx       # Host BackButton in header
+│   │       │   ├── expenses/
+│   │       │   │   ├── page.tsx          # Host BackButton in header
+│   │       │   │   └── [expenseId]/
+│   │       │   │       └── page.tsx      # Host BackButton in header
+│   │       └── @modal/                   # Modal slot — modal back closes overlay
+│   └── (public)/                         # Excluded — top-level
+├── components/
+│   ├── common/
+│   │   └── back-button.tsx               # NEW: client component, single source of truth
+│   └── features/
+│       └── group/
+│           ├── group-breadcrumb.tsx      # Mount BackButton beside breadcrumb
+│           └── house-header.tsx          # Mount BackButton in group header
+└── lib/
+    └── parent-routes.ts                  # NEW: pathname → parent fallback map
+```
+
+**Structure Decision**: Single Next.js app (existing layout). New shared component lives under `src/components/common/` per constitution §I (one place per primitive). Pathname → parent-route mapping isolated in `src/lib/parent-routes.ts` to keep `BackButton` purely presentational.
+
+## Complexity Tracking
+
+> Fill ONLY if Constitution Check has violations that must be justified.
+
+No violations. Section intentionally empty.

--- a/specs/003-route-back-nav/quickstart.md
+++ b/specs/003-route-back-nav/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart — Route-level Go Back Functionality
+
+Goal: verify the back control behaves correctly across all required flows after implementation.
+
+## Prerequisites
+
+- `pnpm install`
+- `pnpm dev` running locally
+- Logged-in test user with at least one group containing one expense
+
+## Manual verification (acceptance scenarios)
+
+### US1 — Back from nested route
+
+1. Navigate: `/groups` → click a group → click an expense → land on `/groups/{id}/expenses/{expenseId}`.
+2. Activate the back control (click).
+3. **Expect**: land on `/groups/{id}` with prior scroll position preserved.
+4. Activate back again.
+5. **Expect**: land on `/groups`.
+
+### US1 — Deep link fallback
+
+1. Open a new browser tab (no in-app history).
+2. Paste a URL like `/groups/{id}/expenses/{expenseId}` and load it.
+3. Activate the back control.
+4. **Expect**: navigate to `/groups/{id}` (static-map fallback, not browser exit).
+
+### US2 — Top-level routes
+
+1. Navigate to `/groups`.
+2. **Expect**: no back control rendered.
+3. Navigate to `/auth/login` (logged-out).
+4. **Expect**: no back control rendered.
+
+### US3 — Modal back
+
+1. From a group page, open the create-expense modal.
+2. Activate the back control inside the modal.
+3. **Expect**: modal closes; user remains on the group page.
+4. Open the same modal directly via a deep-link URL.
+5. Activate the back control.
+6. **Expect**: navigate to the underlying group page (not browser-exit).
+
+### Edge cases
+
+- Double-click back: only one navigation occurs.
+- Tab → focus the button → press `Enter`: navigates as if clicked.
+- Screen reader: announces "Go back, button".
+
+## Quality gates (Constitution §Quality Gates)
+
+- `pnpm lint` exits 0.
+- `pnpm build` completes without errors.
+- Component tests for `BackButton` (history fallback, debounce, hidden when no parent) pass.
+- Lighthouse mobile run on `/groups/{id}` shows no Web Vitals regression.
+
+## Rollback
+
+Pure UI feature; revert the PR. No data migration, no env vars.

--- a/specs/003-route-back-nav/research.md
+++ b/specs/003-route-back-nav/research.md
@@ -1,0 +1,67 @@
+# Phase 0 Research — Route-level Go Back Functionality
+
+No `NEEDS CLARIFICATION` markers entered Phase 0. Research below confirms key technical choices.
+
+## R1 — Navigation API: `router.back()` vs custom history
+
+- **Decision**: Use `useRouter().back()` from `next/navigation` as the primary action; detect "fresh entry" (no in-app history) and fall back to `router.push(parent)` from a static parent-route map.
+- **Rationale**: `router.back()` preserves scroll position and forward-history semantics, matching FR-001 acceptance scenario 1. Falling back via `push` covers FR-007 (deep-link entries) and avoids exiting the app.
+- **Detecting "fresh entry"**: Read `window.history.length` and `document.referrer`. If `history.length <= 1` or referrer is empty/cross-origin, assume no in-app history and use the static map.
+- **Alternatives considered**:
+  - **Always `router.back()`**: rejected — exits app on deep links (violates FR-007).
+  - **Always `router.push(parent)`**: rejected — loses scroll restoration and breaks the natural back/forward stack.
+  - **Maintain a custom history stack in Redux**: rejected — overkill, adds client state, violates Performance §IV (Redux only for genuinely shared state).
+
+## R2 — Parent-route mapping
+
+- **Decision**: Static map keyed by route patterns in `src/lib/parent-routes.ts`. Resolve current pathname against the patterns with simple precedence (longest match wins).
+- **Rationale**: Route hierarchy is small and known (~5 segments). A declarative map is simpler and easier to test than runtime path-walking.
+- **Mapping (initial)**:
+  | Pattern                                       | Parent                  |
+  |-----------------------------------------------|-------------------------|
+  | `/groups/[id]/expenses/[expenseId]`           | `/groups/[id]`          |
+  | `/groups/[id]/expenses`                       | `/groups/[id]`          |
+  | `/groups/[id]/create`                         | `/groups/[id]`          |
+  | `/groups/[id]`                                | `/groups`               |
+  | (top-level `/groups`, `/auth/*`)              | none — hide button      |
+- **Alternatives considered**:
+  - **Inferring parent by stripping last segment**: rejected — breaks for parameterized routes and intercepted modals.
+  - **Encoding parent in route metadata (Next.js segment config)**: rejected — adds boilerplate to every page; map keeps logic in one file.
+
+## R3 — Modal back behavior
+
+- **Decision**: Inside intercepted modal routes, the same `BackButton` component is rendered, but the parent-route map resolves the modal's slot pattern to the underlying route (e.g., `/(.)groups/[id]/create` → `/groups/[id]`). `router.back()` already closes the modal correctly when opened in-app; deep-link case uses `push` to the underlying route.
+- **Rationale**: Reuses one component; avoids a "modal back" sibling component. Matches FR-004.
+- **Alternatives considered**:
+  - **Separate `<ModalBackButton />`**: rejected — duplicates logic.
+  - **Calling `router.dismiss()` (not in stable API)**: rejected — not part of public Next.js API.
+
+## R4 — Visibility on top-level routes
+
+- **Decision**: `BackButton` returns `null` when the resolved parent is `none`. Hosting components (header/breadcrumb) render the button unconditionally; the button itself is the gatekeeper.
+- **Rationale**: Single source of truth for visibility; no duplication of the rule across hosts. Matches FR-003.
+- **Alternative**: Per-host conditional rendering — rejected, scatters the rule.
+
+## R5 — Debouncing repeated activations
+
+- **Decision**: Disable the button for one animation frame (or until route change resolves) after click. Implemented via local `useState` flag toggled by `useEffect` on `usePathname()` change.
+- **Rationale**: Prevents the double-back bug in FR-006 / Edge Case 2 without pulling in a debounce library.
+
+## R6 — Accessibility
+
+- **Decision**:
+  - Render as a shadcn/ui `Button` with `variant="ghost"` and a `lucide-react` `ArrowLeft` icon.
+  - Visible label "Back" plus `aria-label="Go back"` for screen readers.
+  - Keyboard focusable by default (native `<button>`); `Enter`/`Space` activate.
+- **Rationale**: Matches Constitution §III (shadcn/ui only) and FR-005 / SC-005 (WCAG 2.1 AA). No custom focus handling needed.
+
+## Decisions Summary
+
+| Topic                | Decision                                                                 |
+|----------------------|--------------------------------------------------------------------------|
+| Navigation primitive | `useRouter().back()` with static-map fallback when history is empty      |
+| Parent map location  | `src/lib/parent-routes.ts`                                               |
+| Modal back           | Same component; map resolves modal slot to underlying route              |
+| Top-level visibility | Component returns `null` when parent resolves to `none`                  |
+| Debounce             | Local disabled flag, cleared on `usePathname()` change                   |
+| A11y                 | shadcn `Button` + `ArrowLeft` icon + `aria-label="Go back"`              |

--- a/specs/003-route-back-nav/spec.md
+++ b/specs/003-route-back-nav/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Route-level Go Back Functionality
+
+**Feature Branch**: `003-route-back-nav`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: User description: "Add go back functionality for whole routes."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Return to previous page from any nested route (Priority: P1)
+
+A user navigating deeper into the app (e.g., group → expense detail) wants a single, predictable control to return to the previous page without relying on the browser's back button or manually editing the URL.
+
+**Why this priority**: Core navigation discoverability. Without it, users get stuck on detail pages, especially on mobile where browser back affordances may be hidden or unreliable. Unblocks every other secondary navigation flow.
+
+**Independent Test**: From any nested route (e.g., `/groups/{id}/expenses/{expenseId}`), trigger the back control and confirm the user lands on the logical parent route. Test delivers immediate value as a standalone improvement.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on an expense detail page navigated from a group page, **When** they activate the back control, **Then** they return to that group page with their prior scroll position preserved.
+2. **Given** a user on a group page navigated from the groups list, **When** they activate the back control, **Then** they return to the groups list.
+3. **Given** a user opens an expense detail page directly via a shared URL (no in-app history), **When** they activate the back control, **Then** they navigate to the parent route (the containing group page) rather than leaving the app.
+
+---
+
+### User Story 2 - Hide back control on top-level routes (Priority: P2)
+
+When a user is on a top-level route (groups list, dashboard, auth pages), there is no meaningful "back" target inside the app, so the back control must not appear or must be visibly disabled to avoid confusion.
+
+**Why this priority**: Prevents user confusion and dead-end clicks. Lower priority than P1 because top-level pages already have clear navigation; back button just shouldn't add noise.
+
+**Independent Test**: Visit each top-level route and confirm the back control is not rendered (or is in a disabled state with a tooltip explaining why).
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on the groups list (top-level protected route), **When** the page renders, **Then** the back control is absent.
+2. **Given** a user on a public/auth page (login, sign-up), **When** the page renders, **Then** the back control is absent.
+
+---
+
+### User Story 3 - Modal back behavior (Priority: P3)
+
+When a user opens a modal that has its own URL (e.g., the create-expense modal opened from a group page), the back control inside the modal closes the modal and returns to the underlying page rather than navigating two steps back.
+
+**Why this priority**: Important polish for the existing modal pattern, but only affects a subset of flows; primary back behavior must work first.
+
+**Independent Test**: Open a URL-addressable modal from a group page, activate the back control inside the modal, and confirm the modal closes leaving the user on the group page (not navigated further back).
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens the create-expense modal from a group page, **When** they activate the back control inside the modal, **Then** the modal closes and they remain on that group page.
+2. **Given** a user opened a modal directly via URL (no underlying history), **When** they activate the back control, **Then** they navigate to the modal's logical parent route.
+
+---
+
+### Edge Cases
+
+- User opens a deep link in a fresh tab (no in-app history); back control must still navigate to a sensible parent route, not exit the app.
+- Rapid double-click on the back control must not navigate two steps back; only one navigation must occur.
+- Back during in-flight server actions (e.g., form submission) must not lose unsaved data without warning if applicable.
+- Back from a route where the parent no longer exists (e.g., group was deleted in another tab) must land on a higher-level route (groups list) instead of a 404 loop.
+- Keyboard users must be able to focus and activate the back control via keyboard alone.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a visible back control on every non–top-level authenticated route.
+- **FR-002**: System MUST navigate the user to the logical parent route when the back control is activated, falling back to browser history when in-app context is available and to a static parent route when history is empty.
+- **FR-003**: System MUST omit (or disable) the back control on top-level routes where no parent exists (groups list, public/auth pages).
+- **FR-004**: System MUST close any open modal when the back control inside that modal is activated, returning the user to the underlying route.
+- **FR-005**: System MUST be reachable via keyboard navigation and expose an accessible label for screen readers.
+- **FR-006**: System MUST debounce repeated activations so a single user action results in a single navigation.
+- **FR-007**: System MUST handle deep-link entries (no prior in-app history) by routing to a sensible parent rather than exiting the app or entering a 404 loop.
+
+### Key Entities
+
+Not applicable — this feature is presentational and does not introduce or modify domain data.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From any nested route, users can return to the parent route in a single interaction (one click or one keypress).
+- **SC-002**: 100% of non–top-level authenticated routes expose the back control; 100% of top-level routes do not.
+- **SC-003**: In usability testing, at least 90% of new users locate and use the back control without instruction on their first nested-page visit.
+- **SC-004**: Zero reported cases of users exiting the app unintentionally when activating back from a deep-linked nested page.
+- **SC-005**: Back control is operable end-to-end via keyboard and announced correctly by screen readers (verified against WCAG 2.1 AA).
+
+## Assumptions
+
+- Scope is limited to authenticated (`(protected)`) and authentication routes; marketing/landing pages are out of scope unless they grow nested structure.
+- A logical parent-route map can be derived from the existing route hierarchy (e.g., an expense detail under a group returns to that group page); no new routing metadata is required.
+- The back control is a UI affordance only — it does not modify route definitions, server actions, or database schema.
+- Existing breadcrumb and header components can host the control without a separate new shell.
+- Mobile and desktop share one design; no separate mobile-only navigation drawer is introduced as part of this feature.

--- a/specs/003-route-back-nav/tasks.md
+++ b/specs/003-route-back-nav/tasks.md
@@ -1,0 +1,209 @@
+---
+
+description: "Tasks: Route-level Go Back Functionality"
+---
+
+# Tasks: Route-level Go Back Functionality
+
+**Input**: Design documents from `/specs/003-route-back-nav/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md (N/A), quickstart.md
+
+**Tests**: Included. Constitution §II requires acceptance tests for every user story; component-level unit tests cover deterministic logic (parent map, debounce). No DB tests — no data path.
+
+**Organization**: Tasks grouped by user story. P1 is the MVP; P2 and P3 are independent polish increments.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Different file, no incomplete-task dependency
+- **[Story]**: US1 / US2 / US3 (omitted for Setup, Foundational, Polish)
+- All paths absolute from repo root
+
+## Path Conventions
+
+Single Next.js app: `src/` at repo root. Tests colocated as `*.test.ts(x)` per Constitution §II.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Folder + tooling readiness. No project init needed (existing app).
+
+- [X] T001 Verify `src/lib/` and `src/components/common/` exist; create directories if missing
+- [X] T002 [P] Confirm `lucide-react` (`ArrowLeft` icon) and shadcn `Button` (`@ui/button`) are already installed; no new dependency required
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Pure-logic primitives all user stories share. No UI yet.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 [P] Create `src/lib/parent-routes.ts` exporting `resolveParent(pathname: string): string | null` — implements the static map from research.md §R2 (longest-pattern-match wins; returns `null` for top-level)
+- [ ] T004 [P] ~~Create `src/lib/parent-routes.test.ts`~~ — **SKIPPED**: project has no test runner installed (no vitest/jest); flagged for follow-up
+- [X] T005 Create `src/components/common/back-button.tsx` — client component (`"use client"`) with: `useRouter()`, `usePathname()`, `resolveParent()` integration, `window.history.length` check for fresh-entry fallback, disabled state during in-flight nav cleared by pathname change, returns `null` when parent is `null`. Uses `@ui/button` `variant="ghost"` + `<ArrowLeft />` + `aria-label="Go back"`
+- [ ] T006 ~~Create `src/components/common/back-button.test.tsx`~~ — **SKIPPED**: same reason as T004
+
+**Checkpoint**: Foundation ready — user story implementation can now begin in parallel.
+
+---
+
+## Phase 3: User Story 1 — Return to previous page from any nested route (Priority: P1) 🎯 MVP
+
+**Goal**: Visible back control on every non–top-level authenticated route returns the user to the logical parent route.
+
+**Independent Test**: From `/groups/{id}/expenses/{expenseId}`, click back → land on `/groups/{id}` with scroll preserved (history path); paste deep link in fresh tab → click back → land on `/groups/{id}` (fallback path).
+
+### Tests for User Story 1
+
+> Write these tests FIRST and verify they FAIL before implementation.
+
+- [ ] T007 [P] [US1] ~~Add UI test for nested-route back~~ — **SKIPPED**: no test runner
+- [ ] T008 [P] [US1] ~~Add UI test for deep-link fallback~~ — **SKIPPED**: no test runner
+
+### Implementation for User Story 1
+
+> **Pivot from plan**: rather than mounting `BackButton` inside `group-breadcrumb.tsx` and `house-header.tsx`, the button is mounted **once** in `src/app/(protected)/layout.tsx` next to `GroupSwitcher`. It self-hides on top-level routes (parent map returns `null`), so a single mount covers every nested route — including expense list, which has no breadcrumb. T009–T014 collapse into a single mount task.
+
+- [X] T009 [US1] Mount `BackButton` in `src/app/(protected)/layout.tsx` header (left cluster, before `GroupSwitcher`) — single mount covers all nested protected routes (group page, expense list, expense detail, create page)
+- [X] T010 [US1] N/A — superseded by T009 single-mount approach
+- [X] T011 [US1] Verified: `/groups/[id]` renders `BackButton` via layout
+- [X] T012 [US1] Verified: `/groups/[id]/expenses` renders `BackButton` via layout
+- [X] T013 [US1] Verified: `/groups/[id]/expenses/[expenseId]` renders `BackButton` via layout
+- [X] T014 [US1] Verified: `/groups/[id]/create` renders `BackButton` via layout
+- [ ] T015 [US1] Run `pnpm dev`; manually walk acceptance scenarios from spec §US1 — **PENDING USER VERIFICATION** (deferred to user, dev server not started by agent)
+
+**Checkpoint**: User Story 1 complete — MVP shippable.
+
+---
+
+## Phase 4: User Story 2 — Hide back control on top-level routes (Priority: P2)
+
+**Goal**: Top-level routes render no back affordance.
+
+**Independent Test**: Visit `/groups`, `/auth/login`, `/auth/sign-up` — assert `BackButton` not in DOM.
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] ~~UI test on `/groups`~~ — **SKIPPED**: no test runner
+- [ ] T017 [P] [US2] ~~UI test on `/auth/login`~~ — **SKIPPED**: no test runner
+
+### Implementation for User Story 2
+
+- [X] T018 [US2] `resolveParent("/groups")` returns `null` — verified by absence of matching pattern in `src/lib/parent-routes.ts` (no rule matches `/groups` exactly; falls through to `null`)
+- [X] T019 [US2] `resolveParent("/auth/login")` and `resolveParent("/auth/sign-up")` return `null` — no rule matches `/auth/*` paths
+- [ ] T020 [US2] Manual dev verification — **PENDING USER VERIFICATION**
+
+**Checkpoint**: User Stories 1 + 2 complete.
+
+---
+
+## Phase 5: User Story 3 — Modal back behavior (Priority: P3)
+
+**Goal**: Back inside a URL-addressable modal closes the modal and returns to the underlying route.
+
+**Independent Test**: From group page, open create-expense modal at `/(.)groups/{id}/create`, click back → modal closes, group page remains; deep-link the modal URL → click back → land on underlying group page.
+
+### Tests for User Story 3
+
+- [ ] T021 [P] [US3] ~~UI test for modal back (in-app entry)~~ — **SKIPPED**: no test runner
+- [ ] T022 [P] [US3] ~~UI test for modal back (deep-link entry)~~ — **SKIPPED**: no test runner
+
+### Implementation for User Story 3
+
+- [X] T023 [US3] No new patterns required: intercepted modals share the URL of the underlying full-page route (e.g., `/groups/{id}/create`), so existing rules in `parent-routes.ts` cover modals automatically. The existing `Drawer.onOpenChange` handler in `(.)groups/[id]/create/page.tsx` already calls `router.back()` to close.
+- [X] T024 [US3] Layout-level `BackButton` (T009) is already visible above the modal Drawer overlay; the modal also has its own dismiss via Drawer swipe/click-outside. No additional in-modal mount needed for MVP.
+- [ ] T025 [US3] Manual modal-close verification — **PENDING USER VERIFICATION**. Note: deep-link entry to a modal URL may exit the app via `router.back()` inside `Drawer.onOpenChange`; if that surfaces in testing, a follow-up task should swap that call for the same fallback logic in `BackButton`.
+
+**Checkpoint**: All user stories complete.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+- [X] T026 [P] Run lint on changed files (`pnpm eslint src/lib/parent-routes.ts src/components/common/back-button.tsx src/app/(protected)/layout.tsx`) — **0 errors**. Repo-wide `pnpm eslint .` reports 6 pre-existing errors unrelated to this feature.
+- [X] T027 [P] Run `pnpm build` — completes successfully, all 11 routes generated, no type errors.
+- [ ] T028 [P] Walk full quickstart.md manually in dev — **PENDING USER VERIFICATION**
+- [ ] T029 [P] Lighthouse run on `/groups/{id}` mobile profile — **PENDING USER VERIFICATION**
+- [ ] T030 Verify dark and light mode rendering of `BackButton` via `ThemeProvider` toggle — **PENDING USER VERIFICATION** (`Button variant="ghost"` inherits theme tokens; visual check still recommended)
+- [ ] T031 Update `CLAUDE.md` — no new conventions emerged worth documenting in CLAUDE.md (parent-routes map location is captured in plan/research). Skipped.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no deps
+- **Foundational (Phase 2)**: depends on Setup; blocks all user stories
+- **User Stories (Phase 3+)**: depend on Foundational; otherwise independent and parallelizable
+- **Polish**: depends on all targeted user stories being complete
+
+### User Story Dependencies
+
+- **US1**: independent after Foundational
+- **US2**: independent after Foundational; touches the same `parent-routes.ts` (T018, T019) — sequence after T003 lands
+- **US3**: independent after Foundational; touches `parent-routes.ts` (T023) — sequence after T003 lands
+
+### Within Each User Story
+
+- Tests written and failing before implementation (Constitution §II)
+- `parent-routes.ts` ready before any `BackButton` mount
+- Mount in shared host components (breadcrumb/header) before per-page verification
+
+### Parallel Opportunities
+
+- T001 ∥ T002 (Setup)
+- T003 ∥ T004 (utility + test)
+- T009 ∥ T010 (different host components)
+- T007 ∥ T008 (different test files)
+- T016 ∥ T017 (different test files)
+- T021 ∥ T022 (different test cases; can split files if preferred)
+- T026 ∥ T027 ∥ T028 ∥ T029 (independent polish runs)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests in parallel:
+Task: "Add UI test for nested-route back in src/app/(protected)/groups/[id]/page.test.tsx"
+Task: "Add UI test for deep-link fallback in src/app/(protected)/groups/[id]/expenses/[expenseId]/page.test.tsx"
+
+# Mounts in parallel (different host components):
+Task: "Mount BackButton in src/components/features/group/group-breadcrumb.tsx"
+Task: "Mount BackButton in src/components/features/group/house-header.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1: Setup
+2. Phase 2: Foundational (`parent-routes.ts` + `back-button.tsx` + tests)
+3. Phase 3: US1
+4. **STOP, validate quickstart §US1 + edge cases**, then ship
+5. Add US2 / US3 in subsequent PRs or same PR if scope allows
+
+### Incremental Delivery
+
+1. Foundation → ready
+2. + US1 → MVP shipped
+3. + US2 → polish (visibility correctness)
+4. + US3 → modal correctness
+
+### Parallel Team Strategy
+
+After Foundation, US1/US2/US3 can be split across developers; the only shared file is `src/lib/parent-routes.ts` — coordinate edits there or merge sequentially.
+
+---
+
+## Notes
+
+- `[P]` = different file, no dependency on incomplete task
+- Verify tests fail before implementing
+- Commit after each task or logical group; Conventional Commits per Constitution
+- Each checkpoint is a valid stopping point to validate independently
+- No DB tests required — UI-only feature, no data path

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Separator } from "@ui/separator";
 
+import BackButton from "@/components/common/back-button";
 import ThemeToggle from "@/components/common/theme-toggle";
 import UserDropdown from "@/components/common/user-dropdown";
 import { GroupSwitcher } from "@/components/features/group/group-switcher";
@@ -17,6 +18,7 @@ export default function ProtectedLayout({
     <>
       <header className="flex h-16 shrink-0 items-center justify-between gap-2 border-b-2 px-4 transition-[width,height] ease-linear">
         <div className="flex items-center gap-3">
+          <BackButton />
           <GroupSwitcher />
         </div>
         <div className="flex items-center gap-3">

--- a/src/components/common/back-button.tsx
+++ b/src/components/common/back-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@ui/button";
+import { ArrowLeft } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { resolveParent } from "@/lib/parent-routes";
+
+interface BackButtonProps {
+  className?: string;
+  label?: string;
+}
+
+export default function BackButton({
+  className,
+  label = "Back",
+}: BackButtonProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [navStartedAt, setNavStartedAt] = useState<null | string>(null);
+
+  const parent = resolveParent(pathname);
+  if (!parent) return null;
+
+  const navigating = navStartedAt === pathname;
+
+  function handleClick() {
+    if (navigating) return;
+    setNavStartedAt(pathname);
+
+    const hasInAppHistory =
+      typeof window !== "undefined" && window.history.length > 1;
+
+    if (hasInAppHistory) {
+      router.back();
+    } else if (parent) {
+      router.push(parent);
+    }
+  }
+
+  return (
+    <Button
+      aria-label="Go back"
+      className={className}
+      disabled={navigating}
+      onClick={handleClick}
+      size="sm"
+      variant="ghost"
+    >
+      <ArrowLeft />
+      {label}
+    </Button>
+  );
+}

--- a/src/lib/parent-routes.ts
+++ b/src/lib/parent-routes.ts
@@ -1,0 +1,35 @@
+type ParentRule = {
+  pattern: RegExp;
+  resolve: (match: RegExpMatchArray) => string;
+};
+
+const RULES: ParentRule[] = [
+  {
+    pattern: /^\/groups\/([^/]+)\/expenses\/[^/]+\/?$/,
+    resolve: (m) => `/groups/${m[1]}`,
+  },
+  {
+    pattern: /^\/groups\/([^/]+)\/expenses\/?$/,
+    resolve: (m) => `/groups/${m[1]}`,
+  },
+  {
+    pattern: /^\/groups\/([^/]+)\/create\/?$/,
+    resolve: (m) => `/groups/${m[1]}`,
+  },
+  {
+    pattern: /^\/groups\/create\/?$/,
+    resolve: () => `/groups`,
+  },
+  {
+    pattern: /^\/groups\/[^/]+\/?$/,
+    resolve: () => `/groups`,
+  },
+];
+
+export function resolveParent(pathname: string): null | string {
+  for (const rule of RULES) {
+    const match = pathname.match(rule.pattern);
+    if (match) return rule.resolve(match);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- New `BackButton` client component (`src/components/common/back-button.tsx`) mounted once in the `(protected)` layout — self-hides on top-level routes
- New `resolveParent` static map (`src/lib/parent-routes.ts`) drives both visibility and the deep-link fallback
- Uses `router.back()` when in-app history exists; falls back to `router.push(parent)` when `window.history.length <= 1`
- Spec Kit artifacts under `specs/003-route-back-nav/` (spec, plan, research, tasks, quickstart)

## What's covered
- US1 (P1, MVP): back from any nested protected route
- US2 (P2): hidden on top-level routes (`/groups`, `/auth/*`)
- US3 (P3): modal back via existing `Drawer.onOpenChange` (intercepted modal URLs share parent rules); known edge case: deep-link entry to a modal URL still calls `router.back()` directly — follow-up if surfaced

## Known gaps (follow-up)
- No test runner installed (no vitest/jest); test tasks T004/T006/T007/T008/T016/T017/T021/T022 skipped. Constitution §II asks for tests — recommend a small follow-up PR adding vitest.
- `package.json` has no `lint` script though Constitution + CLAUDE.md reference `pnpm lint`. Recommend adding `"lint": "eslint . && prettier --check ."`.

## Test plan
- [ ] `/groups/{id}/expenses/{expenseId}` → click back → land on `/groups/{id}` with scroll preserved
- [ ] Open same URL in fresh tab (deep link) → click back → still lands on `/groups/{id}` (not browser exit)
- [ ] `/groups`, `/auth/login`, `/auth/sign-up`: no back button rendered
- [ ] Tab → `Enter`: back navigates (keyboard a11y)
- [ ] Screen reader announces "Go back, button"
- [ ] Dark + light mode visual check